### PR TITLE
Remove sqlite as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "pg": "^6.0.2"
   },
   "devDependencies": {
-    "nodemon": "^1.9.2",
-    "sqlite3": "^3.1.4"
+    "nodemon": "^1.9.2"
   }
 }


### PR DESCRIPTION
This dependency causes issues on some peoples vm when running `npm install`. Also, no one is using sqlite and no one **should** be using sqlite, so.....