### PR TITLE
Update misleading error from sass-middleware

### DIFF
--- a/lib/sass-middleware.js
+++ b/lib/sass-middleware.js
@@ -16,7 +16,8 @@ const sassMiddleware = (options) => {
       })
       fs.writeFileSync(`${destination}${cssFilename}.css`, rendered.css.toString())
     } catch (e) {
-      console.log(`\n 🙈🚨 SOURCE SASS FILE NOT FOUND FOR ${cssFilename.substring(1)}.${extension} 🚨🙈 \n`)
+      console.log(`\n 🙈🚨 UNABLE TO GENERATE CSS FROM SASS FILE: ${cssFilename.substring(1)}.${extension}  🚨🙈 \n 
+      ERROR: ${e} \n`)
     }
     
     next()


### PR DESCRIPTION
Log original error returned by `sass.renderSync`  instead of assuming sass file not found.